### PR TITLE
Clarify osquery toolchain step in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,19 @@ Please note that LLVM itself must be compiled with libc++ when enabling the `EBP
 
 **This should work fine on any recent Linux distribution. The binaries generated with this toolchain are portable and can be deployed on any distro >= CentOS 6/Ubuntu 16.04**
 
-Download the osquery-toolchain: https://github.com/osquery/osquery-toolchain/releases/download/1.1.0/osquery-toolchain-1.1.0-x86_64.tar.xz
+As root, download and install the osquery-toolchain:
+
+```bash
+cd /tmp
+wget https://github.com/osquery/osquery-toolchain/releases/download/1.1.0/osquery-toolchain-1.1.0-x86_64.tar.xz 
+tar -xf /tmp/ebpfpub/build/osquery-toolchain-1.1.0-x86_64.tar.xz -C /opt
+```
 
 1. Obtain the source code: `git clone --recursive https://github.com/trailofbits/ebpfpub`
 2. In case the `--recursive` flag was not provided, run `git submodule update --init --recursive`
 3. Enter the source folder: `cd ebpfpub`
 4. Create the build folder: `mkdir build && cd build`
-5. Configure the project: `cmake -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo -DEBPF_COMMON_TOOLCHAIN_PATH:PATH=/path/to/osquery-toolchain -DEBPFPUB_ENABLE_INSTALL:BOOL=true -DEBPFPUB_ENABLE_EXAMPLES:BOOL=true -DEBPF_COMMON_ENABLE_TESTS:BOOL=true ..`
+5. Configure the project: `cmake -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo -DEBPF_COMMON_TOOLCHAIN_PATH:PATH=/opt/osquery-toolchain -DEBPFPUB_ENABLE_INSTALL:BOOL=true -DEBPFPUB_ENABLE_EXAMPLES:BOOL=true -DEBPF_COMMON_ENABLE_TESTS:BOOL=true ..`
 6. Build the project: `cmake --build . -j $(($(nproc) + 1))`
 7. Run the tests: `cmake --build . --target run-ebpf-common-tests`
 


### PR DESCRIPTION
Make it a little clearer, make it a copy/paste of the commands to grab the osquery toolchain. Putting it in `/opt` specifically seems to avoid an error with just leaving it in an arbitrary location.